### PR TITLE
Clear relPath

### DIFF
--- a/core/components/filelister/elements/snippets/snippet.filelister.php
+++ b/core/components/filelister/elements/snippets/snippet.filelister.php
@@ -124,6 +124,8 @@ if (!is_dir($curPath) && is_file($curPath)) {
 } elseif (!is_dir($curPath)) {
     /* if an invalid path, set to base */
     $curPath = $path;
+    /* and clear relPath */
+    $relPath = '';
 }
 
 /* check download access */


### PR DESCRIPTION
When the path to the file/dir is not valid and `$fd` have value in it, then all links will become invalid. 
Because `$relPath` is not cleared and will be prefixed to query string in call `$modx->makeUrl()`.